### PR TITLE
Add 32 and 64-bit Chrome filepath compatibility

### DIFF
--- a/Application.java
+++ b/Application.java
@@ -24,7 +24,6 @@ class Application{
 				case 4 : r.exec("cmd.exe");	System.out.println("It might not open");	break;
 				case 5 :
 					String path = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
-					String architecture = System.getProperty("os arch");
 					try {
 						r.exec(path);
 					}

--- a/Application.java
+++ b/Application.java
@@ -22,8 +22,22 @@ class Application{
 				case 2 : r.exec("C:\\Program Files\\Microsoft Office\\Office12\\winword.exe");	break;
 				case 3 : r.exec("calc.exe");	break;
 				case 4 : r.exec("cmd.exe");	System.out.println("It might not open");	break;
-				case 5 : r.exec("C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe");	
-						 System.out.println("Have a patience! Chrome is opening...");	break;
+				case 5 :
+					String path = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+					String architecture = System.getProperty("os arch");
+					try {
+						r.exec(path);
+					}
+					catch (java.io.IOException e) {
+						System.out.println("64-bit Chrome not found. Trying 32-bit.");
+						try {
+							r.exec("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+						}
+						catch (java.io.IOException f) {
+							System.out.println("Could not find Chrome, user either does not have it installed, or it is installed in an atypical location."); break;
+						}
+						System.out.println("Have a patience! Chrome is opening...");	break;
+					}
 				case 6 : r.exec("C:\\Program Files\\Microsoft Office\\Office12\\EXCEL.exe");	break;
 				case 7 : r.exec("C:\\Windows\\System32\\SnippingTool.exe"); break;
 				case 8 : r.exec("C:\\Windows\\System32\\dialer.exe");	break;


### PR DESCRIPTION
Only works if Chrome is installed, and installed in the default directory. Fix #2.